### PR TITLE
adding `gulpplugin` to keywords

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,7 +10,8 @@
   "keywords": [
     "gulp",
     "xls",
-    "json"
+    "json",
+    "gulpplugin"
   ],
   "dependencies": {
     "gulp-util": "~2.2.0",


### PR DESCRIPTION
this plugin is not showing on http://gulpjs.com/plugins/ because of this missing keyword